### PR TITLE
fixed empty unit

### DIFF
--- a/InfoDisplayExtension.lua
+++ b/InfoDisplayExtension.lua
@@ -26,7 +26,7 @@ InfoDisplayExtension.modDir = g_currentModDirectory;
 local g_additionalUnits = nil
 
 function InfoDisplayExtension:formatVolume(liters, precision, unit, fillTypeName)
-  unit = unit == "" and nil or (unit == false and "" or unit)
+  unit = unit ~= "" and (unit == false and "" or unit) or nil
 
   if g_additionalUnits ~= nil and fillTypeName ~= nil then
     local formattedLiters, formattedUnit = g_additionalUnits:formatFillLevel(liters, fillTypeName)


### PR DESCRIPTION
Small change to fix an issue with formatting an empty unit. During additional testing, I noticed that fillType, which has no unitShort defined, when passed to the function unit parameter as "" (empty string) is formatted incorrectly. This small change fixed everything and now all cases are handled correctly and the unit is formatted as it should be.